### PR TITLE
[DEV-8439] Teacher images via WP plugin are blurry

### DIFF
--- a/programs-remote-listings/rs-connect.php
+++ b/programs-remote-listings/rs-connect.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name: Retreat Booking Guru Connect
 Description: Connect to Retreat Booking Guru to show program listings on your site and link to registration forms.
-Version: 2.3.2
+Version: 2.3.3
 Author: Retreat Guru
 Author URI: http://retreat.guru/booking
 */
@@ -12,7 +12,7 @@ class RS_Connect
 {
     protected $options = null;
     protected $program = null;
-    public static $plugin_version = 'wp2.3.2'; // todo: always update this with wp + the plugin Version set above
+    public static $plugin_version = 'wp2.3.3'; // todo: always update this with wp + the plugin Version set above
 
     public function __construct()
     {

--- a/programs-remote-listings/rs-connect.php
+++ b/programs-remote-listings/rs-connect.php
@@ -174,12 +174,14 @@ class RS_Connect
 
             $program_url = $this->get_page_url('programs').$this->program->ID.'/'.$this->program->slug;
             $meta_description = ! empty($this->program->seo_description) ? $this->program->seo_description : wp_trim_words($this->program->text, 50, '...');
+            $options = get_option('rs_remote_settings');
+            $image_size = ! empty($options['rs_template']['image_size']) ? $options['rs_template']['image_size'] : 'medium';
 
             if (! empty($this->program->text)) {
                 echo '<meta property="og:url" content="'.$program_url.'/" />'."\n";
                 echo '<meta property="og:title" content="'.$this->program->title.'" />'."\n";
 
-                $medium = $this->program->photo_details->medium ?? null;
+                $medium = $this->program->photo_details->{$image_size} ?? null;
                 if (is_object($medium)) {
                     echo '<meta property="og:image" content="'.$medium->url.'" />'."\n";
                     echo '<meta property="og:image:width" content="'.$medium->width.'" />'."\n";

--- a/programs-remote-listings/templates/shortcode-programs-single.php
+++ b/programs-remote-listings/templates/shortcode-programs-single.php
@@ -32,6 +32,8 @@ $teacher_details = ! empty($rs_the_program->teacher_details) ? $rs_the_program->
 $teacher_objects = $teacher_details && ! empty($teacher_details->teacher_objects) ? $teacher_details->teacher_objects : [];
 $teacher_settings = $teacher_details && ! empty($teacher_details->teacher_settings) ? $teacher_details->teacher_settings : false;
 
+$image_size = ! empty($options['rs_template']['image_size']) ? $options['rs_template']['image_size'] : 'medium';
+
 ?>
 
 <?php
@@ -127,13 +129,13 @@ if (is_array($shortcode_atts)) extract($shortcode_atts); ?>
                     $teacher_slug = ! empty($teacher->slug) ? $teacher->slug : '';
                     $teacher_name = ! empty($teacher->name) ? $teacher->name : '';
                     $teacher_text = ! empty($teacher->text) ? $teacher->text : '';
-                    $teacher_image = $teacher->photo_details->medium ?? null;
+                    $teacher_image = $teacher->photo_details->{$image_size} ?? null;
                     $teacher_url = $RS_Connect->get_page_url('teachers') . $teacher_id . '/' . $teacher_slug;
                     ?>
                     <div class="teacher" style="clear:left; position:relative;">
                         <?php if (isset($teacher_image)) : ?>
                             <div
-                                style="float:left; width:<?php echo $teacher->photo_details->medium->width; ?>px; margin-right:20px;">
+                                style="float:left; width:<?php echo $teacher->photo_details->{$image_size}->width; ?>px; margin-right:20px;">
                                 <a href="<?php echo $teacher_url; ?>" style="float:left; margin:5px 20px 10px 0;">
                                     <img src="<?php echo $teacher_image->url ?? '' ?>" alt="<?php echo $teacher_image->alt ?? 'Teacher profile image'; ?>" style="float:left; margin:5px 20px 10px 0;">
                                 </a>

--- a/programs-remote-listings/templates/shortcode-teachers-single.php
+++ b/programs-remote-listings/templates/shortcode-teachers-single.php
@@ -4,7 +4,8 @@ global $rs_the_teacher;
 global $shortcode_atts;
 
 $options = get_option('rs_remote_settings');
-$teacher_image = $rs_the_teacher->photo_details->medium ?? null;
+$image_size = ! empty($options['rs_template']['image_size']) ? $options['rs_template']['image_size'] : 'medium';
+$teacher_image = $rs_the_teacher->photo_details->{$image_size} ?? null;
 
 ?>
 
@@ -20,7 +21,7 @@ if (is_array($shortcode_atts)) extract($shortcode_atts); ?>
     <div class="entry-content">
         <?php // Program Details ?>
         <div class="rs-teacher-content" style="padding:20px;">
-            <?php if (isset($rs_the_teacher->photo_details->medium)) : ?>
+            <?php if (isset($teacher_image)) : ?>
                 <img src="<?php echo $teacher_image->url ?? ''; ?>" alt="<?php echo $teacher_image->alt ?? 'Teacher profile image'; ?>" class="alignleft" style="padding:0 20px 20px 0px; float: left;">
             <?php endif; ?>
 

--- a/programs-remote-listings/views/admin-settings.php
+++ b/programs-remote-listings/views/admin-settings.php
@@ -105,6 +105,7 @@
                             <?php $image_size = ! empty($options['rs_template']['image_size']) ? $options['rs_template']['image_size'] : 'medium'; ?>
                             <option value="thumbnail" <?php selected($image_size, 'thumbnail') ?>>Small - Square Cropped</option>
                             <option value="medium" <?php selected($image_size, 'medium') ?>>Medium - Uncropped</option>
+                            <option value="large" <?php selected($image_size, 'large') ?>>Large - Uncropped</option>
                         </select>
                     </fieldset>
                 </td>


### PR DESCRIPTION
Small update to the wp listing plugin, to allow centers to use the large format thumbnails, so they don’t have blurry thumbnails on their program listing pages.
We provide the large image size in our wp-json/events legacy api, but the wp-plugin doesn’t have “large” as an option in the settings. Tested this on qa-testing, and it makes the blurry thumbnails clear